### PR TITLE
Update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,10 +14,7 @@
   "bugs": {
     "url": "https://github.com/regexps/copyright-regex/issues"
   },
-  "license": {
-    "type": "MIT",
-    "url": "https://github.com/regexps/copyright-regex/blob/master/LICENSE"
-  },
+  "license": "MIT",
   "files": [
     "index.js"
   ],


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
